### PR TITLE
Rename binary

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs }: 
+  outputs = { self, nixpkgs }:
 
     let pkgs = nixpkgs.legacyPackages.x86_64-linux;
     in {
@@ -20,10 +20,7 @@
         }
       ) {
         enableSeparateDataOutput = false;
-      }).overrideAttrs (old: {
-        installPhase = old.installPhase + ''  
-          ln -s $out/bin/shellify $out/bin/nix-shellify
-        '';
+      }).overrideAttrs(old: {
         buildInputs = old.buildInputs ++ [ pkgs.nix ];
       });
     };

--- a/shellify.cabal
+++ b/shellify.cabal
@@ -59,7 +59,7 @@ library
         shake >=0.19.7 && <0.20,
         unordered-containers >=0.2.19.1 && <0.3
 
-executable shellify
+executable nix-shellify
     import: deps
     main-is: Main.hs
     build-depends:    


### PR DESCRIPTION
Thank you to @cdepillabout for this. I'm merging without the flake buildInput dependency change right now while I understand it. I'm doing this because I'm keen to get the binary rename onto hackage so that it's ready to be pulled into nixpkgs!