### PR TITLE
Update ShellifyTemplate.hs

### DIFF
--- a/src/FlakeTemplate.hs
+++ b/src/FlakeTemplate.hs
@@ -24,4 +24,6 @@ flakeTemplate = [r|{
           devShells.default = import ./shell.nix { $shell_args;separator=' '$ };
         }
       );
-}|]
+}
+
+|]

--- a/src/FlakeTemplate.hs
+++ b/src/FlakeTemplate.hs
@@ -24,4 +24,5 @@ flakeTemplate = [r|{
           devShells.default = import ./shell.nix { $shell_args;separator=' '$ };
         }
       );
-}|]
+}
+|]

--- a/src/ShellifyTemplate.hs
+++ b/src/ShellifyTemplate.hs
@@ -17,4 +17,5 @@ $if(shell_hook)$
   '';
 $endif$
 }
+
 |]

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -136,11 +136,7 @@ theOptions = options "nix-shellify" . words
 instance Show Options
 
 readNixTemplate :: FilePath -> IO Text
-readNixTemplate fileName =
-    stripTrailingNewline <$> readFile ("test/outputs/" <> fileName)
-    where stripTrailingNewline f = bool id stripLastChar (lastCharIsNewline f) f
-          lastCharIsNewline = (== '\n') . last
-          stripLastChar = reverse . tail . reverse
+readNixTemplate fileName = readFile ("test/outputs/" <> fileName)
 
 flakeFile = (<> "-flake.nix")
 shellFile = (<> "-shell.nix")


### PR DESCRIPTION
Adding newlines to templates for the flake.nix and shell.nix files

* added newlines to both src/FlakeTemplate.hs and
  src/ShellifyTemplate.hs templates.
* updated test logic to not strip out newlines to ensure that generated
  templates are matching correct file output.