### PR TITLE
Move to optparse-applicative

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,13 +1,13 @@
 module Main where
 
-import Data.Text (pack)
-import Shellify (runShellify)
-import System.Environment (getArgs, getProgName)
+import Shellify (runShellify, printErrorAndReturnFailure)
+import System.Environment (getArgs)
+import Options(parseCommandLine)
+import Options.Applicative (handleParseResult)
+import Control.Monad ((>=>))
 
 main :: IO ()
-main = do
-  progName <- pack <$> getProgName
-  getTextArgs
-    >>= runShellify . (<>) [progName]
-
-getTextArgs = fmap pack <$> getArgs
+main = getArgs >>=
+         either printErrorAndReturnFailure
+                (handleParseResult >=> runShellify )
+         . parseCommandLine

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689444953,
-        "narHash": "sha256-0o56bfb2LC38wrinPdCGLDScd77LVcr7CrH1zK7qvDg=",
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8acef304efe70152463a6399f73e636bcc363813",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
         "type": "github"
       },
       "original": {

--- a/shellify.cabal
+++ b/shellify.cabal
@@ -29,6 +29,7 @@ common deps
     default-language: GHC2021
     build-depends:
         base >=4.16 && <4.21,
+        optparse-applicative >=0.18.1.0 && <0.19,
         raw-strings-qq >=1.1 && <1.2,
         text >=1.2.5.0 && <2.2
 
@@ -54,7 +55,6 @@ library
         containers >=0.6.5.1 && <0.8,
         data-default >=0.7 && <0.9,
         directory >=1.3.6.2 && <1.4,
-        extra >=1.7.13 && <1.9,
         HStringTemplate >=0.8.8 && <0.9,
         lens >=5.1.1 && <5.4,
         mtl >=2.2.2 && <2.4,
@@ -65,7 +65,7 @@ library
 executable nix-shellify
     import: deps
     main-is: Main.hs
-    build-depends:    
+    build-depends:
         shellify >=0
     hs-source-dirs: app
 
@@ -81,6 +81,8 @@ test-suite haskelltest-test
         Paths_shellify
     ghc-options: -threaded -rtsopts -with-rtsopts=-N
     build-depends:
+        data-default >=0.7 && <0.9,
+        extra >=1.7.16 && <1.8,
         hspec >=2.9.7 && <2.12,
         hspec-core >=2.9.7 && <2.12,
         shellify >=0

--- a/src/Constants.hs
+++ b/src/Constants.hs
@@ -3,37 +3,12 @@ module Constants where
 import Data.Text (Text())
 import Text.RawString.QQ (r)
 
-helpText :: Text -> Text
-helpText progName = "USAGE: " <> progName <> [r| -p [PACKAGES] [--with-flakes]
-       |] <> progName <> [r| shell [PACKAGES]
-
-Pass nix-shell arguments to nix-shellify to have it generate a shell.nix in
-the current directory. You can then just run nix develop or nix-shell in that
-directory to have those packages in your environment. To run nix commands
-you must first install Nix.
-
-Options
-
-    -p / --packages
-    Specify packages for nix-shell compatability
-
-    --command / --run
-    Command to run after creating the shell
-
-    --with-flake
-    When using the -p option to specify packages, use this switch to have a
-    flake.nix created in addition to a shell.nix. This is recommended to ensure
-    the versions of dependencies are kept for reproducibility and so that
-    shells are cached to load faster.
-
-    --allow-local-pinned-registries-to-be-prioritized
-    Pinned local repoisitory URLs are usually taken last when looking for URLs for
-    generated flake.nix files. This is usually desired. If you do however want
-    to see these pinned entries in the flake file as specified in your registry,
-    then set this flag.
-
-    --version
-    Show the version number
+hlDesc :: String
+hlDesc = [r|
+  Pass nix-shell arguments to nix-shellify to have it generate a shell.nix in
+  the current directory. You can then just run nix develop or nix-shell in that
+  directory to have those packages in your environment. To run nix commands
+  you must first install Nix.
 |]
 
 noPackagesError = [r|I can't write out a shell file without any packages specified.

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -40,12 +40,14 @@ commandParser = CommandLineOptions
             long "packages"
          <> short 'p'
          <> metavar "PACKAGE"
+         <> help "Packages to install in the shell.nix file. This option can be used multiple times to specify multiple packages"
          )))
      <*> optional (option str (
             long "command"
          <> long "run"
          <> short 'c'
          <> metavar "COMMAND"
+         <> help "Command to run on initial shell startup"
          ))
      <*> switch (
             long "with-flake"


### PR DESCRIPTION
This is to remove bespoke command line parsing and utilise optparse-applicative. This means that shell completions are provided too.